### PR TITLE
make Grid and Basis structs parametric

### DIFF
--- a/src/basis.jl
+++ b/src/basis.jl
@@ -1,9 +1,9 @@
 using LinearAlgebra
 import Base: eltype
 
-struct Basis
-    grid::Grid
-    L′::AbstractArray
+struct Basis{T,U}
+    grid::Grid{T,U}
+    L′::Array{T,3}
 end
 
 function Basis(r::AbstractVector, n::Integer, args...)

--- a/src/grid.jl
+++ b/src/grid.jl
@@ -1,12 +1,12 @@
 using FastGaussQuadrature
 import Base: size, show, minimum, maximum, eltype
 
-struct Grid
-    X::AbstractMatrix # Quadrature roots
-    W::AbstractMatrix # Quadrature weights
-    N::AbstractMatrix # Inverted weights for matrix elements
-    nel::Integer # Number of finite elements
-    n::Integer # Polynomial order of basis functions
+struct Grid{T<:Number,U<:Integer}
+    X::Matrix{T} # Quadrature roots
+    W::Matrix{T} # Quadrature weights
+    N::Matrix{T} # Inverted weights for matrix elements
+    nel::U # Number of finite elements
+    n::U # Polynomial order of basis functions
     bl::Symbol # Left boundary condition
     br::Symbol # Right boundary condition
 end
@@ -114,7 +114,7 @@ end
 
 Return locations of Gauss–Lobatto quadrature points.
 """
-locs(grid::Grid) = boundary_sel(grid, [grid.X[:,1:end-1]'[:]..., grid.X[end]])
+locs(grid::Grid) = boundary_sel(grid, [grid.X[:,1:end-1]'[:]..., grid.X[end]]::Vector{eltype(grid.X)})
 
 """
     weights(grid)
@@ -123,8 +123,8 @@ Return weights of Gauss–Lobatto quadrature points.
 """
 function weights(grid::Grid)
     bridges = grid.W[1:end-1,end] + grid.W[2:end,1]
-    wl = grid.bl == :dirichlet0 ? 0 : grid.W[1]
-    wr = grid.br == :dirichlet0 ? 0 : grid.W[end]
+    wl = grid.bl == :dirichlet0 ? zero(grid.W[1]) : grid.W[1]
+    wr = grid.br == :dirichlet0 ? zero(grid.W[1]) : grid.W[end]
     boundary_sel(grid, [wl, [grid.W[:,2:end-1] [bridges;wr]]'[:]...])
 end
 


### PR DESCRIPTION
Following the Julia [performance tips](https://docs.julialang.org/en/v1/manual/performance-tips/#Avoid-fields-with-abstract-type-1), this changes the field definitions for `Basis` and `Grid` to be parametric, instead of using the abstract types `AbstractArray` / `AbstractMatrix`. In addition, some other small changes are done to make `locs` and `weights` functions type stable (check with, e.g., `@code_warntype locs(g)`).
I've checked in my own tests that functions using these types directly are orders of magnitude faster without needing explicit type annotations.
I've made all array fields specializations of `Matrix` and `Array` instead of the more general `AbstractMatrix` / `AbstractArray` - if there are any use cases where they can usefully be more general subtypes of AbstractArrays, the definitions could be changed to
```julia
struct Basis{T,U,V}
    grid::Grid{T,U}
    L′::V
end
```
and
```julia
struct Grid{T<:AbstractArray,U<:Integer}
    X::T # Quadrature roots
    W::T # Quadrature weights
    N::T # Inverted weights for matrix elements
    nel::U # Number of finite elements
    n::U # Polynomial order of basis functions
    bl::Symbol # Left boundary condition
    br::Symbol # Right boundary condition
end
```
which should also work for achieving type stability, but is more generic.